### PR TITLE
Patch/nasc

### DIFF
--- a/echopype/commongrid/__init__.py
+++ b/echopype/commongrid/__init__.py
@@ -1,6 +1,7 @@
-from .api import compute_MVBS, compute_MVBS_index_binning
+from .api import compute_MVBS, compute_MVBS_index_binning, compute_NASC
 
 __all__ = [
     "compute_MVBS",
     "compute_MVBS_index_binning",
+    "compute_NASC",
 ]

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -1,12 +1,20 @@
 """
 Functions for enhancing the spatial and temporal coherence of data.
 """
+from typing import Union
+
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 from ..utils.prov import add_processing_level, echopype_prov_attrs, insert_input_processing_level
 from .mvbs import get_MVBS_along_channels
+from .nasc import (
+    check_identical_depth,
+    get_depth_bin_info,
+    get_dist_bin_info,
+    get_distance_from_latlon,
+)
 
 
 def _set_var_attrs(da, long_name, units, round_digits, standard_name=None):
@@ -247,131 +255,150 @@ def compute_MVBS_index_binning(ds_Sv, range_sample_num=100, ping_num=100):
     return ds_MVBS
 
 
-# def compute_NASC(
-#     ds_Sv: xr.Dataset,
-#     cell_dist: Union[int, float],  # TODO: allow xr.DataArray
-#     cell_depth: Union[int, float],  # TODO: allow xr.DataArray
-# ) -> xr.Dataset:
-#     """
-#     Compute Nautical Areal Scattering Coefficient (NASC) from an Sv dataset.
+def compute_NASC(
+    ds_Sv: xr.Dataset,
+    cell_dist: Union[int, float],  # TODO: allow xr.DataArray
+    cell_depth: Union[int, float],  # TODO: allow xr.DataArray
+) -> xr.Dataset:
+    """
+    Compute Nautical Areal Scattering Coefficient (NASC) from an Sv dataset.
 
-#     Parameters
-#     ----------
-#     ds_Sv : xr.Dataset
-#         A dataset containing Sv data.
-#         The Sv dataset must contain ``latitude``, ``longitude``, and ``depth`` as data variables.
-#     cell_dist: int, float
-#         The horizontal size of each NASC cell, in nautical miles [nmi]
-#     cell_depth: int, float
-#         The vertical size of each NASC cell, in meters [m]
+    Parameters
+    ----------
+    ds_Sv : xr.Dataset
+        A dataset containing Sv data.
+        The Sv dataset must contain ``latitude``, ``longitude``, and ``depth`` as data variables.
+    cell_dist: int, float
+        The horizontal size of each NASC cell, in nautical miles [nmi]
+    cell_depth: int, float
+        The vertical size of each NASC cell, in meters [m]
 
-#     Returns
-#     -------
-#     xr.Dataset
-#         A dataset containing NASC
+    Returns
+    -------
+    xr.Dataset
+        A dataset containing NASC
 
-#     Notes
-#     -----
-#     The NASC computation implemented here corresponds to the Echoview algorithm PRC_NASC
-#     https://support.echoview.com/WebHelp/Reference/Algorithms/Analysis_Variables/PRC_ABC_and_PRC_NASC.htm#PRC_NASC  # noqa
-#     The difference is that since in echopype masking of the Sv dataset is done explicitly using
-#     functions in the ``mask`` subpackage so the computation only involves computing the
-#     mean Sv and the mean height within each cell.
+    Notes
+    -----
+    The NASC computation implemented here corresponds to the Echoview algorithm PRC_NASC
+    https://support.echoview.com/WebHelp/Reference/Algorithms/Analysis_Variables/PRC_ABC_and_PRC_NASC.htm#PRC_NASC  # noqa
+    The difference is that since in echopype masking of the Sv dataset is done explicitly using
+    functions in the ``mask`` subpackage so the computation only involves computing the
+    mean Sv and the mean height within each cell.
 
-#     In addition, here the binning of pings into individual cells is based on the actual horizontal
-#     distance computed from the latitude and longitude coordinates of each ping in the Sv dataset.
-#     Therefore, both regular and irregular horizontal distance in the Sv dataset are allowed.
-#     This is different from Echoview's assumption of constant ping rate, vessel speed, and sample
-#     thickness when computing mean Sv.
-#     """
-#     # Check Sv contains lat/lon
-#     if "latitude" not in ds_Sv or "longitude" not in ds_Sv:
-#         raise ValueError("Both 'latitude' and 'longitude' must exist in the input Sv dataset.")
+    In addition, here the binning of pings into individual cells is based on the actual horizontal
+    distance computed from the latitude and longitude coordinates of each ping in the Sv dataset.
+    Therefore, both regular and irregular horizontal distance in the Sv dataset are allowed.
+    This is different from Echoview's assumption of constant ping rate, vessel speed, and sample
+    thickness when computing mean Sv.
+    """
+    # Check Sv contains lat/lon
+    if "latitude" not in ds_Sv or "longitude" not in ds_Sv:
+        raise ValueError("Both 'latitude' and 'longitude' must exist in the input Sv dataset.")
 
-#     # Check if depth vectors are identical within each channel
-#     if not ds_Sv["depth"].groupby("channel").map(check_identical_depth).all():
-#         raise ValueError(
-#             "Only Sv data with identical depth vectors across all pings "
-#             "are allowed in the current compute_NASC implementation."
-#         )
+    # Check if depth vectors are identical within each channel
+    if not ds_Sv["depth"].groupby("channel").map(check_identical_depth).all():
+        raise ValueError(
+            "Only Sv data with identical depth vectors across all pings "
+            "are allowed in the current compute_NASC implementation."
+        )
 
-#     # Get distance from lat/lon in nautical miles
-#     dist_nmi = get_distance_from_latlon(ds_Sv)
+    # Get distance from lat/lon in nautical miles
+    dist_nmi = get_distance_from_latlon(ds_Sv)
 
-#     # Find binning indices along distance
-#     bin_num_dist, dist_bin_idx = get_dist_bin_info(dist_nmi, cell_dist)  # dist_bin_idx is 1-based
+    # Find binning indices along distance
+    bin_num_dist, dist_bin_idx = get_dist_bin_info(dist_nmi, cell_dist)  # dist_bin_idx is 1-based
 
-#     # Find binning indices along depth: channel-dependent
-#     bin_num_depth, depth_bin_idx = get_depth_bin_info(ds_Sv, cell_depth)  # depth_bin_idx is 1-based  # noqa
+    # Find binning indices along depth: channel-dependent
+    bin_num_depth, depth_bin_idx = get_depth_bin_info(ds_Sv, cell_depth)  # depth_bin_idx is 1-based
 
-#     # Compute mean sv (volume backscattering coefficient, linear scale)
-#     # This is essentially to compute MVBS over a the cell defined here,
-#     # which are typically larger than those used for MVBS.
-#     # The implementation below is brute force looping, but can be optimized
-#     # by experimenting with different delayed schemes.
-#     # The optimized routines can then be used here and
-#     # in commongrid.compute_MVBS and clean.estimate_noise
-#     sv_mean = []
-#     for ch_seq in np.arange(ds_Sv["channel"].size):
-#         # TODO: .compute each channel sequentially?
-#         #       dask.delay within each channel?
-#         ds_Sv_ch = ds_Sv["Sv"].isel(channel=ch_seq).data  # preserve the underlying type
+    # Compute mean sv (volume backscattering coefficient, linear scale)
+    # This is essentially to compute MVBS over the cell defined here,
+    # which are typically larger than those used for MVBS.
+    # The implementation below is brute force looping, but can be optimized
+    # by experimenting with different delayed schemes.
+    # The optimized routines can then be used here and
+    # in commongrid.compute_MVBS and clean.estimate_noise
+    sv_mean_2nasc = []
+    for ch_seq in np.arange(ds_Sv["channel"].size):
+        # TODO: .compute each channel sequentially?
+        #       dask.delay within each channel?
+        ds_Sv_ch = ds_Sv["Sv"].isel(channel=ch_seq).data  # preserve the underlying type
+        ds_Sv_depth = ds_Sv["depth"].isel(channel=ch_seq).data
 
-#         sv_mean_dist_depth = []
-#         for dist_idx in np.arange(bin_num_dist) + 1:  # along ping_time
-#             sv_mean_depth = []
-#             for depth_idx in np.arange(bin_num_depth) + 1:  # along depth
-#                 # Sv dim: ping_time x depth
-#                 Sv_cut = ds_Sv_ch[dist_idx == dist_bin_idx, :][
-#                     :, depth_idx == depth_bin_idx[ch_seq]
-#                 ]
-#                 sv_mean_depth.append(np.nanmean(10 ** (Sv_cut / 10)))
-#             sv_mean_dist_depth.append(sv_mean_depth)
+        sv_mean_dist_depth_2nasc = []
+        for dist_idx in np.arange(bin_num_dist) + 1:  # along ping_time
+            sv_mean_depth_2nasc = []
+            for depth_idx in np.arange(bin_num_depth) + 1:  # along depth
+                # Sv dim: ping_time x depth
+                Sv_cut = ds_Sv_ch[dist_idx == dist_bin_idx, :][
+                    :, depth_idx == depth_bin_idx[ch_seq]
+                ]
+                num_pings_in_cut_cell, num_depth_vals_in_cut_cell = Sv_cut.shape
+                r = ds_Sv_depth[:, depth_idx == depth_bin_idx[ch_seq]][0]
+                # get height of samples -> t
+                # derived from the difference between the corresponding consecutive depths
+                t = np.r_[np.diff(r), np.nan]
+                t = np.vstack([t] * num_pings_in_cut_cell)
+                sv = 10 ** (Sv_cut / 10)
+                # per -> the percentage of not nan samples
+                per = np.mean(np.logical_not(np.isnan(sv))) * 100
+                # num_pings_in_cut_cell * num_depth_vals_in_cut_cell = no. of samples in cut cell
+                sv_mean_depth_2nasc.append(
+                    (
+                        np.nanmean(sv * t)
+                        * (
+                            (num_pings_in_cut_cell * num_depth_vals_in_cut_cell)
+                            / num_pings_in_cut_cell
+                        )
+                        * 4
+                        * np.pi
+                        * 1852**2
+                    )
+                    / (per / 100)
+                )
 
-#         sv_mean.append(sv_mean_dist_depth)
+            sv_mean_dist_depth_2nasc.append(sv_mean_depth_2nasc)
 
-#     # Compute mean height
-#     # For data with uniform depth step size, mean height = vertical size of cell
-#     height_mean = cell_depth
-#     # TODO: generalize to variable depth step size
+        sv_mean_2nasc.append(sv_mean_dist_depth_2nasc)
 
-#     ds_NASC = xr.DataArray(
-#         np.array(sv_mean) * height_mean,
-#         dims=["channel", "distance", "depth"],
-#         coords={
-#             "channel": ds_Sv["channel"].values,
-#             "distance": np.arange(bin_num_dist) * cell_dist,
-#             "depth": np.arange(bin_num_depth) * cell_depth,
-#         },
-#         name="NASC",
-#     ).to_dataset()
+    ds_NASC = xr.DataArray(
+        np.array(sv_mean_2nasc),
+        dims=["channel", "distance", "depth"],
+        coords={
+            "channel": ds_Sv["channel"].values,
+            "distance": np.arange(bin_num_dist) * cell_dist,
+            "depth": np.arange(bin_num_depth) * cell_depth,
+        },
+        name="NASC",
+    ).to_dataset()
 
-#     ds_NASC["frequency_nominal"] = ds_Sv["frequency_nominal"]  # re-attach frequency_nominal
+    ds_NASC["frequency_nominal"] = ds_Sv["frequency_nominal"]  # re-attach frequency_nominal
 
-#     # Attach attributes
-#     _set_var_attrs(
-#         ds_NASC["NASC"],
-#         long_name="Nautical Areal Scattering Coefficient (NASC, m2 nmi-2)",
-#         units="m2 nmi-2",
-#         round_digits=3,
-#     )
-#     _set_var_attrs(ds_NASC["distance"], "Cumulative distance", "m", 3)
-#     _set_var_attrs(ds_NASC["depth"], "Cell depth", "m", 3, standard_name="depth")
+    # Attach attributes
+    _set_var_attrs(
+        ds_NASC["NASC"],
+        long_name="Nautical Areal Scattering Coefficient (NASC, m2 nmi-2)",
+        units="m2 nmi-2",
+        round_digits=3,
+    )
+    _set_var_attrs(ds_NASC["distance"], "Cumulative distance", "m", 3)
+    _set_var_attrs(ds_NASC["depth"], "Cell depth", "m", 3, standard_name="depth")
 
-#     # Calculate and add ACDD bounding box global attributes
-#     ds_NASC.attrs["Conventions"] = "CF-1.7,ACDD-1.3"
-#     ds_NASC.attrs["time_coverage_start"] = np.datetime_as_string(
-#         ds_Sv["ping_time"].min().values, timezone="UTC"
-#     )
-#     ds_NASC.attrs["time_coverage_end"] = np.datetime_as_string(
-#         ds_Sv["ping_time"].max().values, timezone="UTC"
-#     )
-#     ds_NASC.attrs["geospatial_lat_min"] = round(float(ds_Sv["latitude"].min().values), 5)
-#     ds_NASC.attrs["geospatial_lat_max"] = round(float(ds_Sv["latitude"].max().values), 5)
-#     ds_NASC.attrs["geospatial_lon_min"] = round(float(ds_Sv["longitude"].min().values), 5)
-#     ds_NASC.attrs["geospatial_lon_max"] = round(float(ds_Sv["longitude"].max().values), 5)
+    # Calculate and add ACDD bounding box global attributes
+    ds_NASC.attrs["Conventions"] = "CF-1.7,ACDD-1.3"
+    ds_NASC.attrs["time_coverage_start"] = np.datetime_as_string(
+        ds_Sv["ping_time"].min().values, timezone="UTC"
+    )
+    ds_NASC.attrs["time_coverage_end"] = np.datetime_as_string(
+        ds_Sv["ping_time"].max().values, timezone="UTC"
+    )
+    ds_NASC.attrs["geospatial_lat_min"] = round(float(ds_Sv["latitude"].min().values), 5)
+    ds_NASC.attrs["geospatial_lat_max"] = round(float(ds_Sv["latitude"].max().values), 5)
+    ds_NASC.attrs["geospatial_lon_min"] = round(float(ds_Sv["longitude"].min().values), 5)
+    ds_NASC.attrs["geospatial_lon_max"] = round(float(ds_Sv["longitude"].max().values), 5)
 
-#     return ds_NASC
+    return ds_NASC
 
 
 def regrid():

--- a/echopype/tests/commongrid/test_nasc.py
+++ b/echopype/tests/commongrid/test_nasc.py
@@ -1,38 +1,40 @@
-import pytest
+import math
 
 import numpy as np
+import pytest
 
 from echopype import open_raw
 from echopype.calibrate import compute_Sv
-# from echopype.commongrid import compute_NASC
-from echopype.commongrid.nasc import (
-    get_distance_from_latlon,
-    get_depth_bin_info,
-    get_dist_bin_info,
-    get_distance_from_latlon,
-)
-from echopype.consolidate import add_location, add_depth
+from echopype.commongrid import compute_NASC
+from echopype.commongrid.nasc import get_distance_from_latlon
+from echopype.consolidate import add_depth, add_location
 
 
 @pytest.fixture
 def ek60_path(test_path):
-    return test_path['EK60']
+    return test_path["EK60"]
 
 
-# def test_compute_NASC(ek60_path):
-#     raw_path = ek60_path / "ncei-wcsd/Summer2017-D20170620-T011027.raw"
+def test_compute_NASC(ek60_path):
+    raw_path = ek60_path / "ncei-wcsd/Summer2017-D20170620-T011027.raw"
 
-#     ed = open_raw(raw_path, sonar_model="EK60")
-#     ds_Sv = add_depth(add_location(compute_Sv(ed), ed, nmea_sentence="GGA"))
-#     cell_dist = 0.1
-#     cell_depth = 20
-#     ds_NASC = compute_NASC(ds_Sv, cell_dist, cell_depth)
+    ed = open_raw(raw_path, sonar_model="EK60")
+    ds_Sv = add_depth(add_location(compute_Sv(ed), ed, nmea_sentence="GGA"))
+    cell_dist = 0.1
+    cell_depth = 20
+    ds_NASC = compute_NASC(ds_Sv, cell_dist, cell_depth)
 
-#     dist_nmi = get_distance_from_latlon(ds_Sv)
+    dist_nmi = get_distance_from_latlon(ds_Sv)
 
-#     # Check dimensions
-#     da_NASC = ds_NASC["NASC"]
-#     assert da_NASC.dims == ("channel", "distance", "depth")
-#     assert np.all(ds_NASC["channel"].values == ds_Sv["channel"].values)
-#     assert da_NASC["depth"].size == np.ceil(ds_Sv["depth"].max() / cell_depth)
-#     assert da_NASC["distance"].size == np.ceil(dist_nmi.max() / cell_dist)
+    # Check dimensions
+    da_NASC = ds_NASC["NASC"]
+    decimal_places = 5
+    tolerance = 10 ** (-decimal_places)
+    nasc_min = da_NASC.min()
+    nasc_max = da_NASC.max()
+    assert da_NASC.dims == ("channel", "distance", "depth")
+    assert np.all(ds_NASC["channel"].values == ds_Sv["channel"].values)
+    assert da_NASC["depth"].size == np.ceil(ds_Sv["depth"].max() / cell_depth)
+    assert da_NASC["distance"].size == np.ceil(dist_nmi.max() / cell_dist)
+    assert math.isclose(nasc_max, 1.40873285e08, rel_tol=tolerance)
+    assert math.isclose(nasc_min, 0.29729349, rel_tol=tolerance)

--- a/echopype/tests/commongrid/test_nasc.py
+++ b/echopype/tests/commongrid/test_nasc.py
@@ -32,6 +32,7 @@ def test_compute_NASC(ek60_path):
     tolerance = 10 ** (-decimal_places)
     nasc_min = da_NASC.min()
     nasc_max = da_NASC.max()
+
     assert da_NASC.dims == ("channel", "distance", "depth")
     assert np.all(ds_NASC["channel"].values == ds_Sv["channel"].values)
     assert da_NASC["depth"].size == np.ceil(ds_Sv["depth"].max() / cell_depth)


### PR DESCRIPTION
## NASC (Nautical Area Scattering Coefficient) Computation Correction

This PR is opened to propose a solution for https://github.com/OSOceanAcoustics/echopype/pull/1136

### Changes Made:

1. **Conversion Factors:** Conversion factors have been incorporated to facilitate the conversion from backscattering cross-section to scattering cross-section and from meters to nautical miles (nmi).

2. **Computation Approach:**
   - Cells Selection: Cells are chosen based on their depth and distance. The distance calculation is based on latitude and longitude coordinates.
   - NASC Calculation: For each channel and cell, the NASC is computed using the following steps:
     - Multiply the Sv (in linear units) with the height of the samples. The sample height is determined as the difference between consecutive depth values.
     - Compute the mean of the obtained values.
     - Multiply the mean value by the number of samples within the selected cell per the number of pings in the same cell.
     - Further multiply the result by $4 \times \pi \times 1852^2$
     - Finally, divide the obtained result by the percentage of non-NaN samples present in the analysis.
